### PR TITLE
Fix addTreeItem

### DIFF
--- a/tree_model.cpp
+++ b/tree_model.cpp
@@ -1,4 +1,4 @@
-#include "tree_model.h"
+﻿#include "tree_model.h"
 
 TreeModel::TreeModel(QObject *parent) : QAbstractItemModel(parent) {
   _rootItem = std::make_shared<TreeItem>(QVariantList{});
@@ -54,8 +54,8 @@ void TreeModel::addTreeItem(TreeItem *parent, TreeItem *child) {
     endRemoveRows();
   }
 
-  beginInsertRows(QModelIndex(), parent->childCount() - 1,
-                  parent->childCount() - 1);
+  beginInsertRows(QModelIndex(), parent->childCount() > 0 ? parent->childCount() - 1:  0,
+                  parent->childCount() > 0 ? parent->childCount() - 1:  0);
   child->setParentItem(parent);
   parent->appendChild(child);
   endInsertRows();


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/18590422/154827742-a9489a27-76fb-4b04-a0df-7b64abf7b588.jpg)
`beginInsertRows(QModelIndex(), parent->childCount() - 1, parent->childCount() - 1);`

When `treemodel->addtreeitem(root, parent1)` is called for the first time.Because `parent->childcount()` is 0.
_ASSERT: "first >= 0" in file itemmodels\qabstractitemmodel.cpp, line 2758_